### PR TITLE
WIP: use O_PATH for performance

### DIFF
--- a/src/libcrun/cgroup-resources.c
+++ b/src/libcrun/cgroup-resources.c
@@ -1073,7 +1073,7 @@ update_cgroup_v1_resources (runtime_spec_schema_config_linux_resources *resource
       if (UNLIKELY (ret < 0))
         return ret;
 
-      dirfd_blkio = open (path_to_blkio, O_DIRECTORY | O_RDONLY | O_CLOEXEC);
+      dirfd_blkio = open (path_to_blkio, O_DIRECTORY | O_PATH | O_RDONLY | O_CLOEXEC);
       if (UNLIKELY (dirfd_blkio < 0))
         return crun_make_error (err, errno, "open `%s`", path_to_blkio);
 
@@ -1098,11 +1098,11 @@ update_cgroup_v1_resources (runtime_spec_schema_config_linux_resources *resource
       if (UNLIKELY (ret < 0))
         return ret;
 
-      dirfd_netclass = open (path_to_netclass, O_DIRECTORY | O_RDONLY | O_CLOEXEC);
+      dirfd_netclass = open (path_to_netclass, O_DIRECTORY | O_PATH | O_RDONLY | O_CLOEXEC);
       if (UNLIKELY (dirfd_netclass < 0))
         return crun_make_error (err, errno, "open `%s`", path_to_netclass);
 
-      dirfd_netprio = open (path_to_netprio, O_DIRECTORY | O_RDONLY | O_CLOEXEC);
+      dirfd_netprio = open (path_to_netprio, O_DIRECTORY | O_PATH | O_RDONLY | O_CLOEXEC);
       if (UNLIKELY (dirfd_netprio < 0))
         return crun_make_error (err, errno, "open `%s`", path_to_netprio);
 
@@ -1119,7 +1119,7 @@ update_cgroup_v1_resources (runtime_spec_schema_config_linux_resources *resource
       ret = append_paths (&path_to_htlb, err, CGROUP_ROOT "/hugetlb", path, NULL);
       if (UNLIKELY (ret < 0))
         return ret;
-      dirfd_htlb = open (path_to_htlb, O_DIRECTORY | O_RDONLY | O_CLOEXEC);
+      dirfd_htlb = open (path_to_htlb, O_DIRECTORY | O_PATH | O_RDONLY | O_CLOEXEC);
       if (UNLIKELY (dirfd_htlb < 0))
         return crun_make_error (err, errno, "open `%s`", path_to_htlb);
 
@@ -1156,7 +1156,7 @@ update_cgroup_v1_resources (runtime_spec_schema_config_linux_resources *resource
       if (UNLIKELY (ret < 0))
         return ret;
 
-      dirfd_mem = open (path_to_mem, O_DIRECTORY | O_RDONLY | O_CLOEXEC);
+      dirfd_mem = open (path_to_mem, O_DIRECTORY | O_PATH | O_RDONLY | O_CLOEXEC);
       if (UNLIKELY (dirfd_mem < 0))
         return crun_make_error (err, errno, "open `%s`", path_to_mem);
 
@@ -1174,7 +1174,7 @@ update_cgroup_v1_resources (runtime_spec_schema_config_linux_resources *resource
       if (UNLIKELY (ret < 0))
         return ret;
 
-      dirfd_pid = open (path_to_pid, O_DIRECTORY | O_RDONLY | O_CLOEXEC);
+      dirfd_pid = open (path_to_pid, O_DIRECTORY | O_PATH | O_RDONLY | O_CLOEXEC);
       if (UNLIKELY (dirfd_pid < 0))
         return crun_make_error (err, errno, "open `%s`", path_to_pid);
 
@@ -1194,7 +1194,7 @@ update_cgroup_v1_resources (runtime_spec_schema_config_linux_resources *resource
       if (UNLIKELY (ret < 0))
         return ret;
 
-      dirfd_cpu = open (path_to_cpu, O_DIRECTORY | O_RDONLY | O_CLOEXEC);
+      dirfd_cpu = open (path_to_cpu, O_DIRECTORY | O_PATH | O_RDONLY | O_CLOEXEC);
       if (UNLIKELY (dirfd_cpu < 0))
         return crun_make_error (err, errno, "open `%s`", path_to_cpu);
       ret = write_cpu_resources (dirfd_cpu, false, resources->cpu, err);
@@ -1208,7 +1208,7 @@ update_cgroup_v1_resources (runtime_spec_schema_config_linux_resources *resource
       if (UNLIKELY (ret < 0))
         return ret;
 
-      dirfd_cpuset = open (path_to_cpuset, O_DIRECTORY | O_RDONLY | O_CLOEXEC);
+      dirfd_cpuset = open (path_to_cpuset, O_DIRECTORY | O_PATH | O_RDONLY | O_CLOEXEC);
       if (UNLIKELY (dirfd_cpuset < 0))
         return crun_make_error (err, errno, "open `%s`", path_to_cpuset);
 

--- a/src/libcrun/cgroup-setup.c
+++ b/src/libcrun/cgroup-setup.c
@@ -50,7 +50,7 @@ initialize_cpuset_subsystem_rec (char *path, size_t path_len, char *cpus, char *
   bool has_cpus = false, has_mems = false;
   int b_len;
 
-  dirfd = open (path, O_DIRECTORY | O_RDONLY | O_CLOEXEC);
+  dirfd = open (path, O_DIRECTORY | O_PATH | O_RDONLY | O_CLOEXEC);
   if (UNLIKELY (dirfd < 0))
     return crun_make_error (err, errno, "open `%s`", path);
 
@@ -174,7 +174,7 @@ initialize_memory_subsystem (const char *path, libcrun_error_t *err)
   cleanup_close int dirfd = -1;
   int i;
 
-  dirfd = open (path, O_DIRECTORY | O_RDONLY | O_CLOEXEC);
+  dirfd = open (path, O_DIRECTORY | O_PATH | O_RDONLY | O_CLOEXEC);
   if (UNLIKELY (dirfd < 0))
     return crun_make_error (err, errno, "open `%s`", path);
 

--- a/src/libcrun/cgroup-systemd.c
+++ b/src/libcrun/cgroup-systemd.c
@@ -164,7 +164,7 @@ setup_rt_runtime (runtime_spec_schema_config_linux_resources *resources,
   if (UNLIKELY (ret < 0))
     return ret;
 
-  dirfd = open (cgroup_path, O_DIRECTORY | O_CLOEXEC);
+  dirfd = open (cgroup_path, O_DIRECTORY | O_PATH | O_CLOEXEC);
   if (UNLIKELY (dirfd < 0))
     return crun_make_error (err, errno, "open `%s`", cgroup_path);
 
@@ -226,7 +226,7 @@ setup_missing_cpu_options_for_systemd (runtime_spec_schema_config_linux_resource
       if (UNLIKELY (ret < 0))
         return ret;
 
-      dirfd = open (cgroup_path, O_DIRECTORY | O_CLOEXEC);
+      dirfd = open (cgroup_path, O_DIRECTORY | O_PATH | O_CLOEXEC);
       if (UNLIKELY (dirfd < 0))
         return crun_make_error (err, errno, "open `%s`", cgroup_path);
 
@@ -266,7 +266,7 @@ setup_cpuset_for_systemd_v1 (runtime_spec_schema_config_linux_resources *resourc
       if (UNLIKELY (ret < 0))
         return ret;
 
-      dirfd_cpuset = open (path_to_cpuset, O_DIRECTORY | O_RDONLY | O_CLOEXEC);
+      dirfd_cpuset = open (path_to_cpuset, O_DIRECTORY | O_PATH | O_RDONLY | O_CLOEXEC);
       if (UNLIKELY (dirfd_cpuset < 0))
         return crun_make_error (err, errno, "open `%s`", path_to_cpuset);
 

--- a/src/libcrun/cgroup-utils.c
+++ b/src/libcrun/cgroup-utils.c
@@ -960,7 +960,7 @@ libcrun_get_cgroup_dirfd (struct libcrun_cgroup_status *status, const char *sub_
   if (UNLIKELY (ret < 0))
     return ret;
 
-  cgroupdirfd = open (path_to_cgroup, O_CLOEXEC | O_NOFOLLOW | O_DIRECTORY | O_RDONLY);
+  cgroupdirfd = open (path_to_cgroup, O_CLOEXEC | O_NOFOLLOW | O_DIRECTORY | O_PATH | O_RDONLY);
   if (UNLIKELY (cgroupdirfd < 0))
     return crun_make_error (err, errno, "open `%s`", path_to_cgroup);
 

--- a/src/libcrun/handlers/krun.c
+++ b/src/libcrun/handlers/krun.c
@@ -232,7 +232,7 @@ libkrun_configure_container (void *cookie, enum handler_configure_phase phase,
         }
     }
 
-  devfd = openat (rootfsfd, "dev", O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+  devfd = openat (rootfsfd, "dev", O_RDONLY | O_DIRECTORY | O_PATH | O_CLOEXEC);
   if (UNLIKELY (devfd < 0))
     return crun_make_error (err, errno, "open /dev directory in `%s`", rootfs);
 

--- a/src/libcrun/linux.c
+++ b/src/libcrun/linux.c
@@ -1769,7 +1769,7 @@ create_missing_devs (libcrun_container_t *container, bool binds, libcrun_error_t
   dev_fds = get_private_data (container)->dev_fds;
   get_private_data (container)->dev_fds = NULL;
 
-  devfd = openat (rootfsfd, "dev", O_CLOEXEC | O_RDONLY | O_DIRECTORY);
+  devfd = openat (rootfsfd, "dev", O_CLOEXEC | O_RDONLY | O_DIRECTORY | O_PATH);
   if (UNLIKELY (devfd < 0))
     return crun_make_error (err, errno, "open /dev directory in `%s`", rootfs);
 
@@ -3467,7 +3467,7 @@ libcrun_set_sysctl (libcrun_container_t *container, libcrun_error_t *err)
     }
 
   get_private_data (container);
-  dirfd = open ("/proc/sys", O_DIRECTORY | O_RDONLY | O_CLOEXEC);
+  dirfd = open ("/proc/sys", O_DIRECTORY | O_PATH | O_RDONLY | O_CLOEXEC);
   if (UNLIKELY (dirfd < 0))
     return crun_make_error (err, errno, "open `/proc/sys`");
 

--- a/src/libcrun/status.c
+++ b/src/libcrun/status.c
@@ -532,7 +532,7 @@ libcrun_container_delete_status (const char *state_root, const char *id, libcrun
   if (UNLIKELY (dir == NULL))
     return crun_make_error (err, 0, "cannot get state directory");
 
-  rundir_dfd = TEMP_FAILURE_RETRY (open (dir, O_DIRECTORY | O_RDONLY | O_CLOEXEC));
+  rundir_dfd = TEMP_FAILURE_RETRY (open (dir, O_DIRECTORY | O_PATH | O_RDONLY | O_CLOEXEC));
   if (UNLIKELY (rundir_dfd < 0))
     return crun_make_error (err, errno, "cannot open run directory `%s`", dir);
 

--- a/src/libcrun/utils.c
+++ b/src/libcrun/utils.c
@@ -830,7 +830,7 @@ lsm_attr_path (const char *lsm, const char *fname, libcrun_error_t *err)
   cleanup_close int lsm_dirfd = -1;
   char *attr_path = NULL;
 
-  attr_dirfd = open ("/proc/thread-self/attr", O_DIRECTORY | O_RDONLY | O_CLOEXEC);
+  attr_dirfd = open ("/proc/thread-self/attr", O_DIRECTORY | O_PATH | O_RDONLY | O_CLOEXEC);
   if (UNLIKELY (attr_dirfd < 0))
     {
       crun_make_error (err, errno, "open `/proc/thread-self/attr`");
@@ -840,7 +840,7 @@ lsm_attr_path (const char *lsm, const char *fname, libcrun_error_t *err)
   // Check for newer scoped interface in /proc/thread-self/attr/<lsm>
   if (lsm != NULL)
     {
-      lsm_dirfd = openat (attr_dirfd, lsm, O_DIRECTORY | O_RDONLY | O_CLOEXEC);
+      lsm_dirfd = openat (attr_dirfd, lsm, O_DIRECTORY | O_PATH | O_RDONLY | O_CLOEXEC);
 
       if (UNLIKELY (lsm_dirfd < 0 && errno != ENOENT))
         {


### PR DESCRIPTION
> [!NOTE]  
> Work in progess. Currently just an experiment.

I wondered if using O_PATH is faster than not using it. As a test I ran this program with and without O_PATH.

```
int main() {
  for (int i = 0; i < 2500000 ; ++i) {
    int dirfd = open ("/tmp", O_DIRECTORY | O_CLOEXEC);
    close(dirfd);
  }
}
```

Result: Using O_PATH was about 30-40% faster.

Let's assume this result can be generalized.
Let's assume using O_PATH is good for perfomance.